### PR TITLE
WIP: Improve error visibility

### DIFF
--- a/app/controllers/fills_controller.rb
+++ b/app/controllers/fills_controller.rb
@@ -15,6 +15,7 @@ class FillsController < ApplicationController
         if @form.fill(fields, validate_only: params[:test] == "1")
           "success"
         else
+          # @TODO: report to sentry?
           "failure"
         end
     rescue CongressForms::Error => e
@@ -51,6 +52,8 @@ class FillsController < ApplicationController
       fills = fills.recent(params[:bio_id])
     end
 
+    # @TODO: can we expose this endpoint to action center to get fill status
+    # reported there?
     render json: fills.order(updated_at: :desc)
   end
 
@@ -127,6 +130,7 @@ class FillsController < ApplicationController
     if @congress_member = CongressMember.find(bio_id)
       @form = @congress_member.form
     else
+      # @TODO: send to sentry?
       render json: {
                status: "error",
                message: "Congress member with provided bio id not found"
@@ -138,6 +142,8 @@ class FillsController < ApplicationController
     fields = params.require(:fields).permit!.to_h
 
     if missing_params = @form.missing_required_params(fields)
+      # @TODO: send to sentry?
+      # careful about sending field content to sentry
       message = "Error: missing fields (#{missing_params.join(', ')})."
       render json: { status: "error", message: message }.to_json
     end

--- a/app/jobs/congress_forms_fill.rb
+++ b/app/jobs/congress_forms_fill.rb
@@ -4,6 +4,7 @@ class CongressFormsFill < ApplicationJob
   end
 
   def reschedule_at(current_time, attempts)
+    # @TODO: decrease attempts? send to sentry here?
     offset = 5 + attempts ** 4 # delayed_job default
     current_time + [offset, 6.hours].max
   end


### PR DESCRIPTION
Just added some comments to places where we might be able to easily get more details about form fill errors.

I think the most promising approach would be to render the json returned by `FillsController#index` in action center so activists can see if a fill failed / so we can count successes/failures in action center itself. Would probably be good to add filtering to the endpoint itself as well (though maybe with how the internet is these days it would be better to just filter the JSON via JS?)

anyway, this is all very exploratory at the moment!